### PR TITLE
Also check if process.platform equals "win32"

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -128,7 +128,7 @@ async function readFileJson(filename) {
 async function appDataPath(windowsSubPath = "Roaming") {
   const path = appDataPath_();
 
-  if (process.platform === "windows") {
+  if (process.platform === "windows" || process.platform === "win32") {
     return path.replace(new RegExp("Roaming$"), windowsSubPath);
   } else if (process.platform === "linux") {
     const uname = await execAsync(`uname -a`);


### PR DESCRIPTION
I'm running node v8.15.1 and process.platform returns "win32". Documentation confirms this: https://nodejs.org/api/process.html#process_process_platform
To make it non breaking it is being checked as an or